### PR TITLE
Fixed missed readOnce -> readExactly for chronos

### DIFF
--- a/src/amysql/private/protocol.nim
+++ b/src/amysql/private/protocol.nim
@@ -579,7 +579,7 @@ proc receivePacket*(conn:Connection, drop_ok: bool = false) {.async, tags:[ReadI
       headerLen = rec.read
     else:
       try:
-        await wait(conn.transp.readOnce(conn.buf[0].addr, NormalLen), ReadTimeOut)
+        await wait(conn.transp.readExactly(conn.buf[0].addr, NormalLen), ReadTimeOut)
       except AsyncTimeoutError:
         success = false
       headerLen = NormalLen


### PR DESCRIPTION
One of the readOnce was left in my previous commit. That has been corrected now.