### PR TITLE
Update conn_connection.nim

### DIFF
--- a/src/amysql/conn_connection.nim
+++ b/src/amysql/conn_connection.nim
@@ -294,11 +294,12 @@ proc open*(connection, user, password:string; database = ""; connectAttrs:Table[
   when defined(posix):
     isPath = connection[0] == '/'
   if isPath:
-    when not defined(ChronosAsync):
-      sock = newAsyncSocket(AF_UNIX, SOCK_STREAM, buffered = true)
-      await connectUnix(sock,connection)
-    else:
-      sock = await connect initTAddress(connection)
+    when defined(posix):
+      when not defined(ChronosAsync):
+        sock = newAsyncSocket(AF_UNIX, SOCK_STREAM, buffered = true)
+        await connectUnix(sock,connection)
+      else:
+        sock = await connect initTAddress(connection)
   else:
     let
       colonPos = connection.find(':')


### PR DESCRIPTION
## issue
In non posix, e.g. Windows, connectUnix is not defined.    However, using previous control flow structure, nim compiler will try resolving `connectUnix`, which leads to an `Error: undeclared identifier: 'connectUnix'`.    
## Solution
add another `when` to prevent `connectUnix` from being resolved